### PR TITLE
Introduce alphaTest attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ A  [9-Slice](http://www.centigrade.de/blog/en/article/modern-user-interface-desi
 | color       |             | #fff              |
 | opacity     |             | 1.0              |
 | transparent |             | true              |
+| alphaTest   |             | 0.0               |
 | debug       |             | false              |
 | map         |             | ''              |
 

--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ if (typeof AFRAME === 'undefined') {
  */
 AFRAME.registerComponent('slice9', {
   schema: {
+    alphaTest: {default: 0.0},
     bottom: {default: 0, min: 0},
     color: {type: 'color', default: '#fff'},
     debug: {default: false},
@@ -42,8 +43,8 @@ AFRAME.registerComponent('slice9', {
       this.plane = new THREE.Mesh(geometry);
     } else {
       material = this.material = new THREE.MeshBasicMaterial({
-        color: data.color, opacity: data.opacity, transparent: data.transparent,
-        wireframe: data.debug
+        alphaTest: data.alphaTest, color: data.color, opacity: data.opacity,
+        transparent: data.transparent, wireframe: data.debug
       });
       this.plane = new THREE.Mesh(geometry, material);
     }
@@ -163,6 +164,7 @@ AFRAME.registerComponent('slice9', {
 
     // Update material if using built-in material.
     if (!data.usingCustomMaterial) {
+      this.material.alphaTest = data.alphaTest;
       this.material.color.setStyle(data.color);
       this.material.opacity = data.opacity;
       this.material.transparent = data.transparent;


### PR DESCRIPTION
This PR introduces `alphaTest (number)` attribute to the component.

Currently the component seems to use alpha blend for cutting off the four corners. But for that purpose using alpha test would be more efficient. And (my understanding is) the area cut by alpha test doesn't write depth so it would be better for render order issues (Related: https://github.com/mozilla/hubs/pull/4470).

But Cons is non-antialiasing. So `alphaTest: false, transparent: true` by default would be good for the quality. Users can opt-in/out on their ends depending on their applications.
